### PR TITLE
SSH host key fix

### DIFF
--- a/src/dracut/95luna/module-setup.sh
+++ b/src/dracut/95luna/module-setup.sh
@@ -19,7 +19,8 @@ install() {
     inst_simple /etc/ssh/ssh_host_ecdsa_key
     inst_simple /etc/ssh/ssh_host_ed25519_key
     mkdir -m 0700 -p "$initdir/root/.ssh"
-    inst_simple /root/.ssh/authorized_keys
+    inst /root/.ssh/id_ed25519.pub /root/.ssh/authorized_keys
+    chmod 600 "$initdir/root/.ssh/authorized_keys"
     
     mkdir -m 0755 -p "$initdir/luna"
     inst "$moddir/ctorrent" "/luna/ctorrent"

--- a/src/dracut/95luna/module-setup.sh
+++ b/src/dracut/95luna/module-setup.sh
@@ -15,7 +15,9 @@ install() {
     inst "$moddir/sshd_config" "/etc/ssh/sshd_config"
     inst "$moddir/bashrc" "/root/.bashrc"
     inst "$moddir/profile" "/root/.profile"
+    inst_simple /etc/ssh/ssh_host_rsa_key
     inst_simple /etc/ssh/ssh_host_ecdsa_key
+    inst_simple /etc/ssh/ssh_host_ed25519_key
     mkdir -m 0700 -p "$initdir/root/.ssh"
     inst_simple /root/.ssh/authorized_keys
     

--- a/src/dracut/95luna/module-setup.sh
+++ b/src/dracut/95luna/module-setup.sh
@@ -19,8 +19,7 @@ install() {
     inst_simple /etc/ssh/ssh_host_ecdsa_key
     inst_simple /etc/ssh/ssh_host_ed25519_key
     mkdir -m 0700 -p "$initdir/root/.ssh"
-    inst /root/.ssh/id_ed25519.pub /root/.ssh/authorized_keys
-    chmod 600 "$initdir/root/.ssh/authorized_keys"
+    inst_simple /root/.ssh/authorized_keys
     
     mkdir -m 0755 -p "$initdir/luna"
     inst "$moddir/ctorrent" "/luna/ctorrent"

--- a/src/dracut/95luna/sshd_config
+++ b/src/dracut/95luna/sshd_config
@@ -1,4 +1,3 @@
-HostKey /etc/ssh/ssh_host_ecdsa_key
 SyslogFacility AUTHPRIV
 AuthorizedKeysFile	.ssh/authorized_keys
 PasswordAuthentication no


### PR DESCRIPTION
This is only part of the fix for the host key issue in the dracut module. I will have to generate a common host key in the image (which seems to be the only way to make this work until we get something better), and fix the `authorized_keys` file on the controller so that it includes itself (as it is copied over to the images).

Issue clustervision/trinityX#80
