### PR TITLE
Several fixes

### DIFF
--- a/bin/luna
+++ b/bin/luna
@@ -839,7 +839,7 @@ def _get_group_interfaces(group):
 
         if_name = '[' + k + ']:'
         interfaces += '{:<{}}{}\n'.format(
-            if_name, if_padding+3, if_net_str[:-1])
+            if_name, if_padding+3, if_net_str.rstrip('\n'))
 
     interfaces = interfaces[:-1]
 

--- a/bin/luna
+++ b/bin/luna
@@ -1167,10 +1167,6 @@ def node_change(**args):
             res = node.set_ip(args['interface'][0], ip=args['interface'][1])
             out &= bool(res)
 
-        if args['bmcip']:
-            res = node.set_ip(ip=args['bmcip'], bmc=True)
-            out &= bool(res)
-
         if args['port']:
             res = node.set('port', args['port'])
             out &= bool(res)
@@ -1785,8 +1781,6 @@ cmd_group = cmd.add_mutually_exclusive_group(required=False)
 cmd_group.add_argument('--group', '-g', help='Group')
 cmd_group.add_argument('--interface', '-i', nargs=2, metavar=('IF', 'X.X.X.X'),
                        help='Assign ip address to interface')
-cmd_group.add_argument('--bmcip', '-b', metavar='X.X.X.X',
-                       help='Assign ip address to BMC interface')
 cmd.add_argument('--mac', metavar='XX:XX:XX:XX:XX',
                  help='Mac address. Specify empty string to erase')
 cmd.add_argument('--switch', '-s', help='Switch')

--- a/bin/luna
+++ b/bin/luna
@@ -967,7 +967,12 @@ def group_change(**args):
         elif bool(args['setnet']):
             return group.set_net_to_if(args['interface'], args['setnet'])
         elif bool(args['delnet']):
-            return group.del_net_from_if(args['interface'])
+            netname = None
+            if type(args['delnet']) == str:
+                netname = args['delnet']
+            ret = group.del_net_from_if(
+                args['interface'], network_name=netname)
+            return ret
         elif bool(args['rename']):
             return group.rename_interface(args['interface'], args['rename'])
         elif args['edit']:
@@ -1730,7 +1735,8 @@ cmd.add_argument('--delete', '-D', action='store_true',
                  help='Delete interface')
 cmd.add_argument('--setnet', '--sn', metavar='NETWORK',
                  help='Set Network for interface or for BMC')
-cmd.add_argument('--delnet', '--dn', action='store_true',
+cmd.add_argument('--delnet', '--dn', action='store',
+                 nargs='?', default=False, const=True,
                  help='Delete Network for interface or for BMC')
 cmd.add_argument('--edit', '-e', action='store_true',
                  help='Edit interface parameters or edit scripts')

--- a/bin/luna
+++ b/bin/luna
@@ -141,8 +141,9 @@ def cluster_change(**args):
         cluster.set('comment', _edit_script(old_comment))
         return True
 
+    args.pop('comment')
     for key in args:
-        if args[key] == None or args[key] == False:
+        if args[key] is None:
             continue
         res = cluster.set(key, args[key])
         if not bool(res):

--- a/luna/__init__.py
+++ b/luna/__init__.py
@@ -52,8 +52,9 @@ def list(collection):
     try:
         mongo_client = pymongo.MongoClient(**utils.helpers.get_con_options())
     except:
-        logger.error("Unable to connect to MongoDB.")
-        raise RuntimeError
+        err_msg = "Unable to connect to MongoDB."
+        logger.error(err_msg)
+        raise RuntimeError, err_msg
 
     logger.debug("Connection to MongoDB was successful.")
 

--- a/luna/base.py
+++ b/luna/base.py
@@ -58,8 +58,9 @@ class Base(object):
         name is used to give default name for mongo document.
         Don't change it is are not sure what you are doing.
         """
-        self.log.error("Please do not call this class directly")
-        raise RuntimeError
+        err_msg = "Please do not call this class directly"
+        self.log.error(err_msg)
+        raise RuntimeError, err_msg
 
     def __str__(self):
         """Returns name"""
@@ -103,16 +104,18 @@ class Base(object):
 
     def _get_object(self, name, mongo_db, create, id):
         if name and type(name) != str:
-            self.log.error("Name of the object should be string.")
-            raise RuntimeError
+            err_msg = "Name of the object should be string."
+            self.log.error(err_msg)
+            raise RuntimeError, err_msg
         if mongo_db:
             self._mongo_db = mongo_db
         else:
             try:
                 client = pymongo.MongoClient(**utils.helpers.get_con_options())
             except:
-                self.log.error("Unable to connect to MongoDB.")
-                raise RuntimeError
+                err_msg = "Unable to connect to MongoDB."
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             self.log.debug("Connection to MongoDB was successful.")
             self._mongo_db = client[db_name]
@@ -123,9 +126,10 @@ class Base(object):
                                                               {'_id': id}]})
 
         if not create and not self._json:
-            self.log.error(("Object '{}' of type '{}' does not exist"
-                            .format(name, self._collection_name)))
-            raise RuntimeError
+            err_msg = ("Object '{}' of type '{}' does not exist"
+                       .format(name, self._collection_name))
+            self.log.error(err_msg)
+            raise RuntimeError, err_msg
 
         elif not create and self._json:
             self._id = self._json['_id']
@@ -133,9 +137,9 @@ class Base(object):
             self._DBRef = DBRef(u'' + self._collection_name, self._id)
 
         elif create and self._json:
-            self.log.error(("'{}' is already created"
-                            .format(self._json['name'])))
-            raise RuntimeError
+            err_msg = "'{}' is already created".format(self._json['name'])
+            self.log.error(err_msg)
+            raise RuntimeError, err_msg
 
         return self._json
 
@@ -367,8 +371,9 @@ class Base(object):
             pass
 
         if not isinstance(remote_dbref, DBRef):
-            self.log.error("Object to unlink from is not a DBRef object")
-            raise RuntimeError
+            err_msg = "Object to unlink from is not a DBRef object"
+            self.log.error(err_msg)
+            raise RuntimeError, err_msg
             return None
 
         elif remote_dbref == self._DBRef:

--- a/luna/base.py
+++ b/luna/base.py
@@ -102,6 +102,9 @@ class Base(object):
         return self._get_object(name, mongo_db, create, id)
 
     def _get_object(self, name, mongo_db, create, id):
+        if name and type(name) != str:
+            self.log.error("Name of the object should be string.")
+            raise RuntimeError
         if mongo_db:
             self._mongo_db = mongo_db
         else:

--- a/luna/bmcsetup.py
+++ b/luna/bmcsetup.py
@@ -83,7 +83,7 @@ class BMCSetup(Base):
 
             bmc = {'name': name, 'userid': userid, 'user': user,
                    'password': password, 'netchannel': netchannel,
-                   'mgmtchannel': mgmtchannel, 'comment': None}
+                   'mgmtchannel': mgmtchannel, 'comment': comment}
 
             self.log.debug("Saving BMC conf '{}' to the datastore".format(bmc))
 

--- a/luna/bmcsetup.py
+++ b/luna/bmcsetup.py
@@ -75,9 +75,10 @@ class BMCSetup(Base):
 
             for key in self._keylist:
                 if type(args[key]) is not self._keylist[key]:
-                    self.log.error(("Argument '{}' should be '{}'"
-                                    .format(key, self._keylist[key])))
-                    raise RuntimeError
+                    err_msg =  ("Argument '{}' should be '{}'"
+                                .format(key, self._keylist[key]))
+                    self.log.error(err_msg)
+                    raise RuntimeError, err_msg
 
             # Store the new BMC config in the datastore
 

--- a/luna/cluster.py
+++ b/luna/cluster.py
@@ -90,39 +90,45 @@ class Cluster(Base):
         cluster = self._get_object('general', mongo_db, create, id)
 
         if cluster and cluster.get('db_version') != db_version:
-            self.log.error("DB version mismatch. Expecting {}"
-                .format(db_version))
-            raise RuntimeError
+            err_msg = "DB version mismatch. Expecting {}".format(db_version)
+            self.log.error(err_msg)
+            raise RuntimeError, err_msg
 
         if create:
             try:
                 path = os.path.abspath(path)
             except:
-                self._logger.error("No path specified.")
-                raise RuntimeError
+                err_msg = "No path specified."
+                self._logger.error(err_msg)
+                raise RuntimeError, err_msg
             if not os.path.exists(path):
-                self._logger.error("Wrong path '{}' specified.".format(path))
-                raise RuntimeError
+                err_msg = "Wrong path '{}' specified.".format(path)
+                self._logger.error(err_msg)
+                raise RuntimeError, err_msg
 
             try:
                 user_id = pwd.getpwnam(user)
             except KeyError:
-                self.log.error("No such user '{}' exists.".format(user))
-                raise RuntimeError
+                err_msg = "No such user '{}' exists.".format(user)
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             try:
                 group = grp.getgrgid(user_id.pw_gid).gr_name
                 group_id = grp.getgrnam(group)
             except KeyError:
-                self.log.error("No such group '{}' exists.".format(group))
-                raise RuntimeError
+                err_msg = "No such group '{}' exists.".format(group)
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             path_stat = os.stat(path)
+
             if (path_stat.st_uid != user_id.pw_uid or
                     path_stat.st_gid != group_id.gr_gid):
-                self.log.error("Path is not owned by '{}:{}'"
-                               .format(user, group))
-                raise RuntimeError
+
+                err_msg = "Path is not owned by '{}:{}'".format(user, group)
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             cluster = {'name': 'general',
                        'nodeprefix': nodeprefix,

--- a/luna/group.py
+++ b/luna/group.py
@@ -43,7 +43,8 @@ class Group(Base):
     def __init__(self, name=None, mongo_db=None, create=False,
                  id=None, prescript='', bmcsetup=None,
                  partscript='', osimage=None, interfaces=[],
-                 postscript='', torrent_if=None, domain=None):
+                 postscript='', torrent_if=None, domain=None,
+                 comment=''):
         """
         prescript   - preinstall script
         bmcsetup    - bmcsetup options
@@ -115,7 +116,7 @@ class Group(Base):
                 'bmcsetup': bmcobj, 'partscript': partscript,
                 'osimage': osimageobj.DBRef, 'interfaces': if_dict,
                 'postscript': postscript, 'domain': domainobj,
-                'torrent_if': torrent_if, 'comment': None,
+                'torrent_if': torrent_if, 'comment': comment,
             }
 
             self.log.debug("Saving group '{}' to the datastore".format(group))

--- a/luna/group.py
+++ b/luna/group.py
@@ -84,8 +84,9 @@ class Group(Base):
                 domainobj = Network(domain, mongo_db=self._mongo_db).DBRef
 
             if interfaces and type(interfaces) is not list:
-                self.log.error("'interfaces' should be list")
-                raise RuntimeError
+                err_msg = "'interfaces' should be list"
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             if not interfaces:
                 interfaces = []

--- a/luna/group.py
+++ b/luna/group.py
@@ -714,11 +714,7 @@ class Group(Base):
 
         return True
 
-    def del_net_from_if(self, interface_name, mute_error=False, version='4'):
-
-        if version not in ['4', '6']:
-            self.log.error("Only IPv4 and IPv6 are supported")
-            return False
+    def del_net_from_if(self, interface_name, network_name=None):
 
         interfaces_dict = self.get('interfaces')
         if_list = self.list_ifs()
@@ -729,16 +725,40 @@ class Group(Base):
             )
             return False
 
+        net = None
+        if network_name:
+            net = self._get_network(netname=network_name)
+
         interface_uuid = if_list[interface_name]
-        if not interfaces_dict[interface_uuid]['network'][version]:
-            if not mute_error:
 
-                self.log.error(
-                    "Network IPv{} is not configured for interface '{}'"
-                    .format(version, interface_name)
-                )
+        # create temporary dict for storing configured networks
+        nets_configured = {'4': None, '6': None}
+        nets_configured['4'] = interfaces_dict[interface_uuid]['network']['4']
+        nets_configured['6'] = interfaces_dict[interface_uuid]['network']['6']
 
+        # if both IPv4 and IPv6 configured and no network_name specified
+        if not net and nets_configured['4'] and nets_configured['6']:
+            self.log.error(
+                 ("Both IPv4 and IPv6 networks are configured for group. " +
+                  "Need to specify network name.")
+            )
             return False
+
+        # if network_name is not the same as configured for interface
+        if net and nets_configured[net.version] != net.DBRef:
+            self.log.error(
+                "Network '{}' is not configured for interface '{}'"
+                .format(network_name, interface_name))
+            return False
+
+        # now we can find IPv4 or IPv6 we will deal with
+        if net:
+            version = net.version
+        else:
+            version = '4'
+            if nets_configured['6']:
+                version = '6'
+            net = self._get_network(netid=nets_configured[version].id)
 
         reverse_links = self.get_back_links()
         for link in reverse_links:
@@ -746,7 +766,8 @@ class Group(Base):
                 node = Node(id=link['DBRef'].id, mongo_db=self._mongo_db)
                 node.del_ip(interface_name, version)
 
-        self.unlink(interfaces_dict[interface_uuid]['network'][version])
+        self.unlink(net.DBRef)
+        self._invalidate_network(net)
         interfaces_dict[interface_uuid]['network'][version] = None
         res = self.set('interfaces', interfaces_dict)
         if not res:
@@ -757,10 +778,8 @@ class Group(Base):
         return True
 
     def del_interface(self, interface_name):
-        self.del_net_from_if(interface_name, mute_error=True, version='4')
-        self.del_net_from_if(interface_name, mute_error=True, version='6')
+        interfaces = self.show_if(interface_name)
 
-        interfaces_dict = self.get('interfaces')
         if_list = self.list_ifs()
 
         if interface_name not in if_list.keys():
@@ -768,6 +787,18 @@ class Group(Base):
                 "Interface '{}' does not exist".format(interface_name)
             )
             return False
+
+        netnames = []
+
+        for ver in ['4', '6']:
+            netname = interfaces['network'][ver]['name']
+            if netname:
+                netnames.append(netname)
+
+        for network_name in netnames:
+            self.del_net_from_if(interface_name, network_name=network_name)
+
+        interfaces_dict = self.get('interfaces')
 
         interface_uuid = if_list[interface_name]
 

--- a/luna/group.py
+++ b/luna/group.py
@@ -747,7 +747,7 @@ class Group(Base):
             return False
 
         # if network_name is not the same as configured for interface
-        if net and nets_configured[net.version] != net.DBRef:
+        if net and nets_configured[str(net.version)] != net.DBRef:
             self.log.error(
                 "Network '{}' is not configured for interface '{}'"
                 .format(network_name, interface_name))
@@ -770,7 +770,7 @@ class Group(Base):
 
         self.unlink(net.DBRef)
         self._invalidate_network(net)
-        interfaces_dict[interface_uuid]['network'][version] = None
+        interfaces_dict[interface_uuid]['network'][str(version)] = None
         res = self.set('interfaces', interfaces_dict)
         if not res:
             self.log.error("Error deleting network for interface '{}'"

--- a/luna/mac_updater.py
+++ b/luna/mac_updater.py
@@ -93,7 +93,7 @@ class MacUpdater(object):
                                 (oid, ip, read, switch_id)))
 
                 vl = netsnmp.VarList(netsnmp.Varbind(oid))
-                res = netsnmp.snmpwalk(varlist, Version=2, DestHost=ip,
+                res = netsnmp.snmpwalk(vl, Version=2, DestHost=ip,
                                        Community=read, UseNumeric=True)
 
                 ifname_oid = '.1.3.6.1.2.1.31.1.1.1.1'  # ifName

--- a/luna/network.py
+++ b/luna/network.py
@@ -210,8 +210,13 @@ class Network(Base):
 
             limit = (1 << (self.maxbits - value)) - 2
             prev_limit = (1 << (self.maxbits - self.get('PREFIX'))) - 2
+
             flist = utils.freelist.set_upper_limit(
                 net['freelist'], limit, prev_limit)
+
+            if self.version == 6:
+                flist = self._flist_to_str(flist)
+                new_num_subnet = str(new_num_subnet)
 
             ret = super(Network, self).set('freelist', flist)
             ret &= super(Network, self).set('NETWORK', new_num_subnet)

--- a/luna/network.py
+++ b/luna/network.py
@@ -38,7 +38,7 @@ class Network(Base):
     def __init__(self, name=None, mongo_db=None,
                  create=False, id=None, version=None,
                  NETWORK=None, PREFIX=None,
-                 ns_hostname=None, ns_ip=None):
+                 ns_hostname=None, ns_ip=None, comment=''):
         """
         create  - should be True if we need create a network
         NETWORK - network
@@ -102,7 +102,8 @@ class Network(Base):
             net = {'name': name, 'NETWORK': num_subnet, 'PREFIX': PREFIX,
                    'freelist': flist, 'ns_hostname': ns_hostname,
                    'ns_ip': None, 'version': version,
-                   'include': None, 'rev_include': None}
+                   'include': None, 'rev_include': None,
+                   'comment': comment}
 
             self.log.debug("Saving net '{}' to the datastore".format(net))
 

--- a/luna/network.py
+++ b/luna/network.py
@@ -67,13 +67,15 @@ class Network(Base):
             if not version:
                 version = utils.ip.get_ip_version(NETWORK)
                 if version == 0:
-                    self.log.error("Unable to determine protocol " +
-                                   "version for given network")
-                    raise RuntimeError
+                    err_msg = ("Unable to determine protocol version " +
+                               "for given network")
+                    self.log.error(err_msg)
+                    raise RuntimeError, err_msg
 
             if version not in [4, 6]:
-                self.log.error("IP version should be 4 or 6")
-                raise RuntimeError
+                err_msg = "IP version should be 4 or 6"
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             maxbits = 32
             if version == 6:

--- a/luna/node.py
+++ b/luna/node.py
@@ -80,9 +80,9 @@ class Node(Base):
         if create:
 
             if not group:
-                self.log.error(
-                    "Group needs to be specified when creating node.")
-                raise RuntimeError
+                err_msg = "Group needs to be specified when creating node."
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             cluster = Cluster(mongo_db=self._mongo_db)
 
@@ -113,7 +113,9 @@ class Node(Base):
         if group:
             # check if group specified is the group node belongs to
             if self.group.DBRef != self._json['group']:
-                raise RuntimeError
+                err_msg = ("DBref of the group is not the same " +
+                           "the node node belongs to")
+                raise RuntimeError, err_msg
 
         self.log = logging.getLogger(__name__ + '.' + self._json['name'])
 

--- a/luna/node.py
+++ b/luna/node.py
@@ -39,8 +39,9 @@ class Node(Base):
 
     log = logging.getLogger(__name__)
 
-    def __init__(self, name=None, mongo_db=None, create=False, id=None,
-                 group=None, localboot=False, setupbmc=True, service=False):
+    def __init__(self, name=None, mongo_db=None, create=False,
+                 id=None, group=None, localboot=False, setupbmc=True,
+                 service=False, comment=''):
         """
         name  - optional
         group - the group the node belongs to; required
@@ -95,7 +96,7 @@ class Node(Base):
             node = {'name': name, 'group': self.group.DBRef, 'interfaces': {},
                     'mac': None, 'switch': None, 'port': None,
                     'localboot': localboot, 'setupbmc': setupbmc,
-                    'service': service, 'comment': None}
+                    'service': service, 'comment': comment}
 
             self.log.debug("Saving node '{}' to the datastore".format(node))
 

--- a/luna/osimage.py
+++ b/luna/osimage.py
@@ -73,8 +73,9 @@ class OsImage(Base):
         osimage = self._get_object(name, mongo_db, create, id)
 
         if bool(kernopts) and type(kernopts) is not str:
-            self.log.error("Kernel options should be 'str' type")
-            raise RuntimeError
+            err_msg = "Kernel options should be 'str' type"
+            self.log.error(err_msg)
+            raise RuntimeError, err_msg
 
         if create:
             cluster = Cluster(mongo_db=self._mongo_db)
@@ -82,28 +83,33 @@ class OsImage(Base):
 
             duplicate = self._mongo_collection.find_one({'path': path})
             if duplicate:
-                self.log.error("Path belongs to osimage '{}'"
-                               .format(duplicate['name']))
-                raise RuntimeError
+                err_msg = ("Path belongs to osimage '{}'"
+                           .format(duplicate['name']))
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             if not os.path.isdir(path):
-                self.log.error("'{}' is not a valid directory".format(path))
-                raise RuntimeError
+                err_msg = "'{}' is not a valid directory".format(path)
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             kernels = self.get_package_ver(path, 'kernel')
             if not kernels:
-                self.log.error("No kernels installed in '{}'".format(path))
-                raise RuntimeError
+                err_msg = "No kernels installed in '{}'".format(path)
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
             elif not kernver:
                 kernver = kernels[0]
             elif kernver not in kernels:
-                self.log.error("Available kernels are '{}'".format(kernels))
-                raise RuntimeError
+                err_msg = "Available kernels are '{}'".format(kernels)
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             grab_list_path = cluster.get('path') + '/templates/' + grab_list
             if not os.path.isfile(grab_list_path):
-                self.log.error("'{}' is not a file.".format(grab_list_path))
-                raise RuntimeError
+                err_msg = "'{}' is not a file.".format(grab_list_path)
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             with open(grab_list_path) as lst:
                 grab_list_content = lst.read()
@@ -360,9 +366,10 @@ class OsImage(Base):
                     break
 
             if not luna_exists:
-                self.log.error("No luna dracut module in osimage '{}'"
-                               .format(self.name))
-                raise RuntimeError
+                err_msg = ("No luna dracut module in osimage '{}'"
+                           .format(self.name))
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             dracut_cmd = (['/usr/sbin/dracut', '--force', '--kver', kernver] +
                           modules_add + modules_remove + drivers_add +

--- a/luna/osimage.py
+++ b/luna/osimage.py
@@ -46,7 +46,7 @@ class OsImage(Base):
     log = logging.getLogger(__name__)
 
     def __init__(self, name=None, mongo_db=None, create=False, id=None,
-                 path='', kernver='', kernopts='',
+                 path='', kernver='', kernopts='', comment='',
                  grab_list='grab_default_centos.lst'):
         """
         path      - path to / of the image (will be converted to absolute)
@@ -116,7 +116,7 @@ class OsImage(Base):
                        'dracutmodules': 'luna,-i18n,-plymouth',
                        'kernmodules': 'ipmi_devintf,ipmi_si,ipmi_msghandler',
                        'grab_exclude_list': grab_list_content,
-                       'grab_filesystems': '/,/boot', 'comment': None}
+                       'grab_filesystems': '/,/boot', 'comment': comment}
 
             self.log.debug("Saving osimage '{}' to the datastore"
                            .format(osimage))

--- a/luna/otherdev.py
+++ b/luna/otherdev.py
@@ -60,8 +60,9 @@ class OtherDev(Base):
             if not network:
                 connected = {}
             elif not ip:
-                self.log.error("IP needs to be specified")
-                raise RuntimeError
+                err_msg = "IP needs to be specified"
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
             else:
                 net = Network(name=network, mongo_db=self._mongo_db)
                 ipnum = net.reserve_ip(ip, ignore_errors=False)

--- a/luna/otherdev.py
+++ b/luna/otherdev.py
@@ -66,6 +66,11 @@ class OtherDev(Base):
             else:
                 net = Network(name=network, mongo_db=self._mongo_db)
                 ipnum = net.reserve_ip(ip, ignore_errors=False)
+                if not ipnum:
+                    err_msg = "Unable to allocate IP in network"
+                    self.log.error(err_msg)
+                    raise RuntimeError, err_msg
+
                 connected = {str(net.DBRef.id): ipnum}
 
             # Store the new device in the datastore

--- a/luna/otherdev.py
+++ b/luna/otherdev.py
@@ -36,7 +36,7 @@ class OtherDev(Base):
     log = logging.getLogger(__name__)
 
     def __init__(self, name=None, mongo_db=None, create=False, id=None,
-                 network=None, ip=None):
+                 network=None, ip=None, comment=''):
         """
         network - the network the device is connected to
         ip      - device's ip
@@ -69,7 +69,7 @@ class OtherDev(Base):
 
             # Store the new device in the datastore
 
-            dev = {'name': name, 'connected': connected, 'comment': None}
+            dev = {'name': name, 'connected': connected, 'comment': comment}
 
             self.log.debug("Saving dev '{}' to the datastore".format(dev))
 

--- a/luna/switch.py
+++ b/luna/switch.py
@@ -102,7 +102,7 @@ class Switch(Base):
 
     def get(self, key):
         if key == 'ip':
-            net_dbref = self.get('network')
+            net_dbref = self._json['network']
 
             if not net_dbref:
                 return None
@@ -111,6 +111,15 @@ class Switch(Base):
             return utils.ip.reltoa(
                 net._json['NETWORK'], self._json['ip'], net.version)
 
+        if key == 'network':
+            net_dbref = self._json['network']
+
+            if not net_dbref:
+                return None
+
+            net = Network(id=net_dbref.id, mongo_db=self._mongo_db)
+            return net.name
+
         return super(Switch, self).get(key)
 
     def get_rel_ip(self):
@@ -118,7 +127,7 @@ class Switch(Base):
 
     def set(self, key, value):
         if key == 'ip':
-            net = Network(id=self.get('network').id, mongo_db=self._mongo_db)
+            net = Network(id=self._json['network'].id, mongo_db=self._mongo_db)
 
             if self._json['ip']:
                 net.release_ip(self._json['ip'])
@@ -129,7 +138,7 @@ class Switch(Base):
             return ret
 
         elif key == 'network':
-            net = Network(id=self.get('network').id, mongo_db=self._mongo_db)
+            net = Network(id=self._json['network'].id, mongo_db=self._mongo_db)
             ip = self._json['ip']
 
             new_net = Network(name=value, mongo_db=self._mongo_db)

--- a/luna/switch.py
+++ b/luna/switch.py
@@ -36,8 +36,9 @@ class Switch(Base):
 
     log = logging.getLogger(__name__)
 
-    def __init__(self, name=None, mongo_db=None, create=False, id=None,
-                 network=None, ip=None, read='public', rw='private', oid=None):
+    def __init__(self, name=None, mongo_db=None, create=False,
+                 id=None, network=None, ip=None, read='public',
+                 rw='private', oid=None, comment=''):
         """
         ip      - ip of the switch
         read    - read community
@@ -83,7 +84,7 @@ class Switch(Base):
             # Store the new switch in the datastore
 
             switch = {'name': name, 'network': net.DBRef, 'ip': ip,
-                      'read': read, 'rw': rw, 'oid': oid, 'comment': None}
+                      'read': read, 'rw': rw, 'oid': oid, 'comment': comment}
 
             self.log.debug("Saving switch '{}' to the datastore"
                            .format(switch))

--- a/luna/switch.py
+++ b/luna/switch.py
@@ -71,15 +71,17 @@ class Switch(Base):
             cluster = Cluster(mongo_db=self._mongo_db)
 
             if not network:
-                self.log.error("Network must be provided")
-                raise RuntimeError
+                err_msg = "Network must be provided"
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             net = Network(name=network, mongo_db=self._mongo_db)
             ip = net.reserve_ip(ip)
 
             if not ip:
-                self.log.error("Could not acquire ip for switch")
-                raise RuntimeError
+                err_msg = "Could not acquire ip for switch"
+                self.log.error(err_msg)
+                raise RuntimeError, err_msg
 
             # Store the new switch in the datastore
 

--- a/luna/utils/freelist.py
+++ b/luna/utils/freelist.py
@@ -209,9 +209,10 @@ def set_upper_limit(flist, end, prev_end):
     # Make sure the new 'end' does not exclude some non-free elements
 
     if last_ip > end:
-        log.error(("Cannot update freelist upper limit. "
-                   "This new limit excludes some already nonfree elements"))
-        raise RuntimeError
+        err_msg = ("Cannot update freelist upper limit. " +
+                   "This new limit excludes some already nonfree elements")
+        log.error(err_msg)
+        raise RuntimeError, err_msg
     last_range = flist[-1]
     flist[-1] = {'start': last_range['start'], 'end': end}
 
@@ -225,9 +226,10 @@ def get_nonfree(flist, limit=None):
     """
 
     if not bool(flist) and (limit is None):
-        log.error("freelist is empty. "
-                  "You must provide a boundary (network prefix)")
-        raise RuntimeError
+        err_msg = ("freelist is empty. " +
+                   "You must provide a boundary (network prefix)")
+        log.error(err_msg)
+        raise RuntimeError, err_msg
 
     elif not bool(flist):
         return range(1, limit)

--- a/luna/utils/helpers.py
+++ b/luna/utils/helpers.py
@@ -40,8 +40,9 @@ def set_mac_node(mac, node, mongo_db=None):
         try:
             mongo_client = pymongo.MongoClient(**get_con_options())
         except:
-            logger.error("Unable to connect to MongoDB.")
-            raise RuntimeError
+            err_msg = "Unable to connect to MongoDB."
+            logger.error(err_msg)
+            raise RuntimeError, err_msg
         logger.debug("Connection to MongoDB was successful.")
         mongo_db = mongo_client[db_name]
     mongo_collection = mongo_db['mac']
@@ -318,8 +319,9 @@ def list_cached_macs(switch_id=None, mongo_db=None):
         try:
             mongo_client = pymongo.MongoClient(**get_con_options())
         except:
-            logger.error("Unable to connect to MongoDB.")
-            raise RuntimeError
+            err_msg = "Unable to connect to MongoDB."
+            logger.error(err_msg)
+            raise RuntimeError, err_msg
         logger.debug("Connection to MongoDB was successful.")
         mongo_db = mongo_client[db_name]
     mongo_collection = mongo_db['switch_mac']
@@ -346,8 +348,9 @@ def list_node_macs(mongo_db=None):
         try:
             mongo_client = pymongo.MongoClient(**get_con_options())
         except:
-            logger.error("Unable to connect to MongoDB.")
-            raise RuntimeError
+            err_msg = "Unable to connect to MongoDB."
+            logger.error(err_msg)
+            raise RuntimeError, err_msg
         logger.debug("Connection to MongoDB was successful.")
         mongo_db = mongo_client[db_name]
 

--- a/luna/utils/ip.py
+++ b/luna/utils/ip.py
@@ -55,9 +55,10 @@ def ntoa(num_ip, ver=4):
         return ip
 
     except:
-        log.error(("Cannot convert '{}' from C"
-                   " to IPv{} format".format(num_ip, ver)))
-        raise RuntimeError
+        err_msg = ("Cannot convert '{}' from C"
+                   " to IPv{} format".format(num_ip, ver))
+        log.error(err_msg)
+        raise RuntimeError, err_msg
 
 
 def aton(ip, ver=4):
@@ -70,8 +71,9 @@ def aton(ip, ver=4):
         return long(absnum)
 
     except:
-        log.error("Cannot convert IP '{}' to C format".format(ip))
-        raise RuntimeError
+        err_msg = "Cannot convert IP '{}' to C format".format(ip)
+        log.error(err_msg)
+        raise RuntimeError, err_msg
 
 
 def reltoa(num_net, rel_ip, ver):
@@ -94,9 +96,10 @@ def atorel(ip, num_net, prefix, ver=4):
 
     # Check if the ip address actually belongs to num_net/prefix
     if not ip_in_net(ip, num_net, prefix, ver):
-        log.error(("Network '{}/{}' does not contain '{}'"
-                   .format(ntoa(num_net, ver), prefix, ip)))
-        raise RuntimeError
+        err_msg = ("Network '{}/{}' does not contain '{}'"
+                   .format(ntoa(num_net, ver), prefix, ip))
+        log.error(err_msg)
+        raise RuntimeError, err_msg
 
     relative_num = long(num_ip - num_net)
 
@@ -115,16 +118,19 @@ def get_num_subnet(ip, prefix, ver=4):
     try:
         prefix = int(prefix)
     except:
-        log.error("Prefix '{}' is invalid, must be 'int'".format(prefix))
-        raise RuntimeError
+        err_msg = "Prefix '{}' is invalid, must be 'int'".format(prefix)
+        log.error(err_msg)
+        raise RuntimeError, err_msg
 
     if ver == 4 and prefix not in range(1, 32):
-        log.error("Prefix should be in the range [1..32]")
-        raise RuntimeError
+        err_msg = "Prefix should be in the range [1..32]"
+        log.error(err_msg)
+        raise RuntimeError, err_msg
 
     if ver == 6 and prefix not in range(1, 128):
-        log.error("Prefix should be in the range [1..128]")
-        raise RuntimeError
+        err_msg = "Prefix should be in the range [1..128]"
+        log.error(err_msg)
+        raise RuntimeError, err_msg
 
     if type(ip) is long or type(ip) is int:
         num_ip = ip
@@ -132,8 +138,9 @@ def get_num_subnet(ip, prefix, ver=4):
         try:
             num_ip = aton(ip, ver)
         except socket.error:
-            log.error("'{}' is not a valid IP".format(ip))
-            raise RuntimeError
+            err_msg = "'{}' is not a valid IP".format(ip)
+            log.error(err_msg)
+            raise RuntimeError, err_msg
 
     num_mask = (((1 << maxbits) - 1)
                 ^ ((1 << (maxbits+1 - prefix) - 1) - 1))

--- a/rpm/luna.spec.in
+++ b/rpm/luna.spec.in
@@ -100,6 +100,7 @@ Requires: vim-minimal
 Requires: grub2
 Requires: rb_libtorrent
 Requires: dracut-config-generic
+Requires: dracut-network
 
 %description client
 Dracut module for Luna deployment tool

--- a/templates/templ_install.cfg
+++ b/templates/templ_install.cfg
@@ -185,7 +185,7 @@ EOF
 
 function restore_selinux_context {
     SEPOLICY_FILE=/etc/selinux/targeted/contexts/files/file_contexts
-    if [ -f ${SEPOLICY_FILE} ]; then
+    if [ -f /sysroot/${SEPOLICY_FILE} ]; then
         chroot /sysroot /bin/bash -c "load_policy -i; setfiles -r / ${SEPOLICY_FILE} /"
     fi
 }

--- a/tests/test_bmcsetup.py
+++ b/tests/test_bmcsetup.py
@@ -29,7 +29,7 @@ class BMCSetupCreateTests(unittest.TestCase):
 
         doc = self.db['bmcsetup'].find_one({'_id': bmc._id})
         expected = {'userid': 3, 'user': 'ladmin', 'password': 'ladmin',
-                    'netchannel': 1, 'mgmtchannel': 1, 'comment': None}
+                    'netchannel': 1, 'mgmtchannel': 1, 'comment': ''}
 
         for attr in expected:
             self.assertEqual(doc[attr], expected[attr])

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -346,7 +346,7 @@ class GroupConfigTests(unittest.TestCase):
             show_if_expected
         )
 
-        self.group.del_net_from_if('eth0', version='6')
+        self.group.del_net_from_if('eth0')
 
         # check if we get the same dictionary at the and
         end_dict = self.db['group'].find_one({'_id': self.group._id})

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -818,6 +818,7 @@ class GroupBootInstallParamsTests(unittest.TestCase):
         # mocking osimage boot stuff
         with mock.patch('os.path'), \
                 mock.patch('shutil.copy'), \
+                mock.patch('os.remove'), \
                 mock.patch('os.chown'), \
                 mock.patch('os.chmod'), \
                 mock.patch('subprocess.Popen') as mock_subprocess_popen, \

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -70,7 +70,7 @@ class GroupCreateTests(unittest.TestCase):
                 'osimage': {str(self.osimage._id): 1}
             },
             'osimage': self.osimage.DBRef,
-            'comment': None
+            'comment': ''
         }
 
         for attr in expected:
@@ -159,7 +159,7 @@ class GroupCreateTests(unittest.TestCase):
                 'bmcsetup': {str(bmcsetup._id): 1},
             },
             'osimage': self.osimage.DBRef,
-            'comment': None,
+            'comment': '',
         }
 
         for attr in expected:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -266,6 +266,9 @@ class NetworkAttributesTestsIPv6(unittest.TestCase):
                           {'start': 39060053, 'end': 18446744073709551614}]
                          )
 
+    def test_change_PREFIX(self):
+        self.assertTrue(self.net.set('PREFIX', 32))
+
 
 class ZoneDataIPv4(unittest.TestCase):
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -74,7 +74,7 @@ class NodeCreateTests(unittest.TestCase):
                 'group': {str(self.group._id): 1},
             },
             'group': self.group.DBRef,
-            'comment': None
+            'comment': ''
         }
 
         if_uuid = None

--- a/tests/test_osimage.py
+++ b/tests/test_osimage.py
@@ -186,6 +186,8 @@ class OsimageMethodsTests(unittest.TestCase):
     def tearDown(self):
         self.sandbox.cleanup()
 
+    @mock.patch('shutil.copy')
+    @mock.patch('os.remove')
     @mock.patch('os.chmod')
     @mock.patch('os.chown')
     @mock.patch('shutil.move')
@@ -203,6 +205,8 @@ class OsimageMethodsTests(unittest.TestCase):
                                  mock_shutil_move,
                                  mock_os_chown,
                                  mock_os_chmod,
+                                 mock_os_remove,
+                                 mock_shutil_copy,
                                  ):
 
         mock_subprocess_popen.return_value.stderr.readline.return_value = ''
@@ -309,6 +313,7 @@ class OsimageMethodsTests(unittest.TestCase):
     @mock.patch('shutil.copy')
     @mock.patch('shutil.move')
     @mock.patch('os.path.isfile')
+    @mock.patch('os.remove')
     @mock.patch('pwd.getpwnam')
     @mock.patch('subprocess.Popen')
     def test_pack_boot(*args):


### PR DESCRIPTION
- it was not possible to delete IPv6 net from CLI. Easiest option was to add version to CLI option, but to make management consistent (hide IP protocol version from CLI) Group.del_net_from_if() started to require network name instead. 
- it was possible to accidentally create object specifying not string as name
- move to shutil.copy/os.remove from shutil.move caused brocken tests
- on luna group list IPv6 nets showed without last number in mask
- after creating network 'comment' fied was not exist, rasing exception on `luna network show`
- changing prefix for IPv6 network caused exception